### PR TITLE
Set referer for getting referring page title to nothing, then avoid fetching empty referers

### DIFF
--- a/includes/pixel.php
+++ b/includes/pixel.php
@@ -3,7 +3,14 @@
 // function to get the title of the referring url
 function wprtt_get_referring_page_title( $url ){
 
-	$response = wp_remote_get( $url );
+	$args = array(
+		'redirection' => 1,
+		'headers' => array (
+			'Referer' => '',
+		),
+	);
+
+	$response = wp_remote_get( $url, $args );
 
 	// if there was no issue grabbing the url, continue
 	if( !is_wp_error( $response ) ){
@@ -42,24 +49,21 @@ if ( isset( $_GET['post'] ) ) {
 	$shared_post_slug = rawurlencode($shared_post->post_name);
 	$shared_post_permalink = get_permalink($shared_post_id);
 
-	if( array_key_exists( 'HTTP_REFERER', $_SERVER ) ){
+	$url = '';
+	$url_title = '';
+	$url_host = '';
 
-		if( isset( $_SERVER['HTTP_REFERER'] ) ){
-			$url = esc_url_raw( $_SERVER['HTTP_REFERER'] );
-		}
+	if ( ! empty( $_SERVER['HTTP_REFERER'] ) ){
 
-		$url_title = wprtt_get_referring_page_title( $url );
-		$url_title = str_replace( ' ', '%20', $url_title );
-
-		$url_host = parse_url( $url, PHP_URL_HOST );
-		$url_path = parse_url( $url, PHP_URL_PATH );
-
-	} else {
-
-		$url = '';
-		$url_title = '';
-		$url_host = '';
+		$url = esc_url_raw( $_SERVER['HTTP_REFERER'] );
 		
+		if ( ! empty( $url ) ) {
+			$url_title = wprtt_get_referring_page_title( $url );
+			$url_title = str_replace( ' ', '%20', $url_title );
+
+			$url_host = parse_url( $url, PHP_URL_HOST );
+			$url_path = parse_url( $url, PHP_URL_PATH );
+		}
 	}
 
 	$value = get_post_meta( $shared_post_id, 'republication_tracker_tool_sharing', true );

--- a/includes/pixel.php
+++ b/includes/pixel.php
@@ -1,117 +1,125 @@
 <?php
+/**
+ * Tracking mechanism for the tracking pixel.
+ */
 
-// function to get the title of the referring url
-function wprtt_get_referring_page_title( $url ){
+/**
+ * Given a URL, try to get the <title>.
+ *
+ * @param String $url The URL to find a <title></title>.
+ * @return void|String The contents of <title></title>.
+ */
+function wprtt_get_referring_page_title( $url ) {
 
 	$args = array(
 		'redirection' => 1,
-		'headers' => array (
+		'headers' => array(
 			'Referer' => '',
 		),
 	);
 
 	$response = wp_remote_get( $url, $args );
 
-	// if there was no issue grabbing the url, continue
-	if( !is_wp_error( $response ) ){
+	// if there was no issue grabbing the url, continue.
+	if ( ! is_wp_error( $response ) ) {
 
-		// find the title element inside of the response body
-		$response = preg_match( "/<title.[^>]*>(.*)<\/title>/siU", $response['body'], $title_matches );
+		// find the title element inside of the response body.
+		$response = preg_match( '/<title.[^>]*>(.*)<\/title>/siU', $response['body'], $title_matches );
 
-		// if a title element was found, let's get the text from it
-		if( $title_matches ){
+		// if a title element was found, let's get the text from it.
+		if ( $title_matches ) {
 
 			// clean up title: remove EOL's and excessive whitespace.
 			$title = preg_replace( '/\s+/', ' ', $title_matches[1] );
 			$title = trim( $title );
 			$title = rawurlencode( $title );
 
-			// return our found title
+			// return our found title.
 			return $title;
-		
-		// if there were no title matches found, don't continue
+
+		// if there were no title matches found, don't continue.
 		} else {
-
 			return;
-
 		}
-
 	}
-
 }
 
 if ( isset( $_GET['post'] ) ) {
 
-	// set up all of our post vars we want to track
+	// set up all of our post vars we want to track.
 	$shared_post_id = absint( $_GET['post'] );
-	$shared_post = get_post($shared_post_id);
+	$shared_post = get_post( $shared_post_id );
 
-	$shared_post_slug = rawurlencode($shared_post->post_name);
-	$shared_post_permalink = get_permalink($shared_post_id);
+	$shared_post_slug = rawurlencode( $shared_post->post_name );
+	$shared_post_permalink = get_permalink( $shared_post_id );
 
 	$url = '';
 	$url_title = '';
 	$url_host = '';
 
-	if ( ! empty( $_SERVER['HTTP_REFERER'] ) ){
-
-		$url = esc_url_raw( $_SERVER['HTTP_REFERER'] );
-		
-		if ( ! empty( $url ) ) {
-			$url_title = wprtt_get_referring_page_title( $url );
-			$url_title = str_replace( ' ', '%20', $url_title );
-
-			$url_host = parse_url( $url, PHP_URL_HOST );
-			$url_path = parse_url( $url, PHP_URL_PATH );
-		}
+	if ( ! empty( $_SERVER['HTTP_REFERER'] ) ) {
+		$url = esc_url_raw( wp_unslash( $_SERVER['HTTP_REFERER'] ) );
 	}
 
-	$value = get_post_meta( $shared_post_id, 'republication_tracker_tool_sharing', true );
-	if ( $value ) {
-		if ( isset( $value[ $url ] ) ) {
-			$value[ $url ]++;
+	if ( ! empty( $url ) ) {
+		$url_host = wp_parse_url( $url, PHP_URL_HOST );
+		$url_path = wp_parse_url( $url, PHP_URL_PATH );
+
+
+		// Try to get the page title.
+		$url_title = wprtt_get_referring_page_title( $url );
+		$url_title = str_replace( ' ', '%20', $url_title );
+	}
+
+	// Avoid tracking hits that have no site to track.
+	if ( ! empty( $url ) && ! empty( $url_host ) ) {
+
+		$value = get_post_meta( $shared_post_id, 'republication_tracker_tool_sharing', true );
+		if ( $value ) {
+			if ( isset( $value[ $url ] ) ) {
+				$value[ $url ]++;
+			} else {
+				$value[ $url ] = 1;
+			}
 		} else {
-			$value[ $url ] = 1;
+			$value = array(
+				$url => 1,
+			);
 		}
-	} else {
-		$value = array(
-			$url => 1
-		);
+		$update = update_post_meta( $shared_post_id, 'republication_tracker_tool_sharing', $value );
+
+		// if our google analytics tag is set, let's push data to it.
+
+		if ( isset( $_GET['ga'] ) && ! empty( $_GET['ga'] ) ) {
+
+			// our base url to ping GA at.
+			$analytics_ping_url = "https://www.google-analytics.com/collect?v=1";
+
+			// create all of our necessary params to track
+			// the docs for these params can be found at: https://developers.google.com/analytics/devguides/collection/analyticsjs/events
+			$analytics_ping_params = array(
+				'tid' => sanitize_text_field( wp_unslash( $_GET['ga'] ) ),
+				'cid' => '555',
+				't' => 'pageview',
+				'dl' => $shared_post_permalink,
+				'dh' => $url_host,
+				'dp' => $shared_post_slug,
+				'dr' => $url,
+				'dt' => $url_title,
+				'an' => 'Republication',
+				'aid' => $url_host,
+				'av' => 'Republication Tracker v1',
+			);
+
+			// create query based on our params array.
+			$analytics_ping_params = http_build_query( $analytics_ping_params );
+
+			$response = wp_remote_post( $analytics_ping_url . '&' . $analytics_ping_params );
+		}
 	}
-	$update = update_post_meta( $shared_post_id, 'republication_tracker_tool_sharing', $value );
-
-	// if our google analytics tag is set, let's push data to it
-	if( isset( $_GET['ga'] ) &&  !empty($_GET['ga'] ) ) {
-
-		// our base url to ping GA at
-		$analytics_ping_url = "https://www.google-analytics.com/collect?v=1";
-
-		// create all of our necessary params to track
-		// the docs for these params can be found at: https://developers.google.com/analytics/devguides/collection/analyticsjs/events
-		$analytics_ping_params = array(
-			'tid' => sanitize_text_field( $_GET['ga'] ),
-			'cid' => '555',
-			't' => 'pageview',
-			'dl' => $shared_post_permalink,
-			'dh' => $url_host,
-			'dp' => $shared_post_slug,
-			'dr' => $url,
-			'dt' => $url_title,
-			'an' => 'Republication',
-			'aid' => $url_host,
-			'av' => 'Republication Tracker v1'
-		);
-
-		// create query based on our params array
-		$analytics_ping_params = http_build_query( $analytics_ping_params );
-
-		$response = wp_remote_post( $analytics_ping_url.'&'.$analytics_ping_params );   
-
-	}
-
 }
 
-// grab our site icon and redirect to it once the script finishes
+// grab our site icon and redirect to it once the script finishes.
 $site_icon_url = get_site_icon_url( 150 );
-wp_safe_redirect($site_icon_url, 303);
+wp_safe_redirect( $site_icon_url, 303 );
 exit;

--- a/readme.txt
+++ b/readme.txt
@@ -31,6 +31,10 @@ In this plugin, the tracking is achieved through an image element included insid
 
 == Changelog ==
 
+= Unreleased changes =
+
+- Fixes bug where Republication pixel's referer lookup function could lead to a loop of looking up itself. Pull request TKTK for issues [#80](https://github.com/Automattic/republication-tracker-tool/issues/80) and [#91](https://github.com/Automattic/republication-tracker-tool/issues/91).
+
 = 1.0.2 =
 
 - Sets a default width for the site icon that is displayed at the bottom of republished articles. Previously it did not have a width set which was causing some sites to experience larger than expected images at the end of their republished articles.


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- When looking up the referer for a hit to the tracking pixel, don't include a referer in the lookup
- If the referer URL is empty, avoid parsing it for a URL host and URL path.

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For https://github.com/Automattic/republication-tracker-tool/issues/80 and https://github.com/Automattic/republication-tracker-tool/issues/91

## Testing/Questions

Features that this PR affects:

- the tracker pixel's referer lookup

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?
- [ ] Does it work?

Steps to test this PR:

0. Set up a Republication site, including Google Analytics
1. View your site's access log, or
2. Copy the republication text, including image, and put that HTML in a file on a server somewhere. It can be a localhost page or a `.test` development server or `your-private-site.example.org` or a GitHub page or a live-edited browser. The HTML from the republication text needs to be rendered so that the image is fetched.
3. View that HTML in a browser.
4. Open the republished article's edit view, and view the number of hits it received. It should have received one, from the URL that you hosted it. Same with your Google Analytics.
5. Extract the tracking pixel `img`'s `src=""` URL, and load that URL directly in your browser.
6. You should not see any new hits for an entry in the hits table for a row with no source URL. Same with your Google Analytics.

## Additional information

INN Member/Labs Client requesting: Center for Public Integrity
